### PR TITLE
fix: 适配 Starlette 1.0.0 的 TemplateResponse 签名

### DIFF
--- a/src/api/routes/static_files.py
+++ b/src/api/routes/static_files.py
@@ -30,15 +30,17 @@ async def verification_page(request: Request, token: str):
         if session.is_expired:
             logger.warning(f"Expired verification token: {token}")
             return templates.TemplateResponse(
+                request,
                 "expired.html",
-                {"request": request, "message": "验证链接已过期，请重新申请加群"}
+                context={"message": "验证链接已过期，请重新申请加群"},
             )
 
         if session.captcha_completed:
             logger.info(f"Verification already completed: {token}")
             return templates.TemplateResponse(
+                request,
                 "completed.html",
-                {"request": request, "message": "您已完成验证，请等待管理员审核"}
+                context={"message": "您已完成验证，请等待管理员审核"},
             )
 
         # Pass expected user_id to template for client-side validation
@@ -49,14 +51,14 @@ async def verification_page(request: Request, token: str):
         captcha_config = captcha_provider.get_frontend_config()
 
         return templates.TemplateResponse(
+            request,
             "verify.html",
-            {
-                "request": request,
+            context={
                 "token": token,
                 "expected_user_id": session.user_id,
                 "captcha_config": captcha_config,
-                "api_base_url": config.api.base_url
-            }
+                "api_base_url": config.api.base_url,
+            },
         )
 
     except HTTPException:
@@ -64,24 +66,19 @@ async def verification_page(request: Request, token: str):
     except Exception as e:
         logger.error(f"Error serving verification page: {e}")
         return templates.TemplateResponse(
+            request,
             "error.html",
-            {"request": request, "message": "页面加载失败，请稍后重试"}
+            context={"message": "页面加载失败，请稍后重试"},
         )
 
 
 @router.get("/success", response_class=HTMLResponse)
 async def success_page(request: Request):
     """Success page after verification."""
-    return templates.TemplateResponse(
-        "success.html",
-        {"request": request}
-    )
+    return templates.TemplateResponse(request, "success.html")
 
 
 @router.get("/", response_class=HTMLResponse)
 async def index_page(request: Request):
     """Index page with bot information."""
-    return templates.TemplateResponse(
-        "index.html",
-        {"request": request}
-    )
+    return templates.TemplateResponse(request, "index.html")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

Fixes #76

Starlette 1.0.0 将 `Jinja2Templates.TemplateResponse` 的签名改为 `(request, name, context=...)`。旧写法把 context dict 作为第二个位置参数传入，导致 `TypeError: unhashable type: 'dict'`，所有验证相关页面返回 500。

## 修改

### 修复

更新 `src/api/routes/static_files.py` 中全部 5 处 `TemplateResponse` 调用，使用新签名格式。

### 测试

新增 pytest 测试套件，在 CI 中自动运行（`.github/workflows/test.yml`）：

- **集成测试**：`/`、`/success`、`/verify`（有效 token、无效 token、已过期、已完成）— 若 `TemplateResponse` 调用错误会返回 500，测试失败
- **回归测试**：直接验证 `TemplateResponse(request, name)` 新签名可用
- **健康检查**：`GET /health`

本地运行：

```powershell
pip install -r requirements-dev.txt
Copy-Item config.example.toml config.toml
pytest -v
```

## 影响范围

- `/verify`（含 expired、completed、error 分支）
- `/success`
- `/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29766971-7512-428f-adb7-546507968585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29766971-7512-428f-adb7-546507968585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

